### PR TITLE
set pnpm install no-frozen-lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ COPY . /app
 WORKDIR /app
 
 FROM base AS prod-deps
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i -P --frozen-lockfile --ignore-scripts
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i -P --no-frozen-lockfile --ignore-scripts
 
 FROM base AS build
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i --frozen-lockfile
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i --no-frozen-lockfile
 RUN pnpm build
 
 FROM base


### PR DESCRIPTION
[![PR-25](https://badgen.net/badge/GitHub.dev/PR-25/blue?icon=visualstudio)](https://github.dev/kaiyuanshe/OpenHackathon-service/pull/25) [![PR-25](https://badgen.net/badge/GitHub%20codespaces/PR-25/black?icon=github)](https://codespaces.new/kaiyuanshe/OpenHackathon-service/pull/25) [![PR-25](https://badgen.net/badge/GitPod.io/PR-25/orange?icon=git)](https://gitpod.io/?autostart=true#https://github.com/kaiyuanshe/OpenHackathon-service/pull/25) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=kaiyuanshe&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

报错信息
```bash
 => [base 5/5] WORKDIR /app                                                                                                                                                                                                            0.1s 
 => ERROR [prod-deps 1/1] RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i -P --frozen-lockfile --ignore-scripts                                                                                                              5.9s
 => ERROR [build 1/2] RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i --frozen-lockfile                                                                                                                                      5.9s
------
 > [prod-deps 1/1] RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i -P --frozen-lockfile --ignore-scripts:
2.374 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-9.15.3.tgz
5.305 ! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a.
5.305 ! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
5.305 
5.776  ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn't match the value found in the lockfile
5.776 
5.776 Update your lockfile using "pnpm install --no-frozen-lockfile"
------
------
 > [build 1/2] RUN --mount=type=cache,id=pnpm,target=/pnpm/store  pnpm i --frozen-lockfile:
2.194 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-9.15.3.tgz
5.312 ! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@9.15.3+sha512.1f79bc245a66eb0b07c5d4d83131240774642caaa86ef7d0434ab47c0d16f66b04e21e0c086eb61e62c77efc4d7f7ec071afad3796af64892fae66509173893a.
5.312 ! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
5.312 
5.797  ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "settings.autoInstallPeers" configuration doesn't match the value found in the lockfile
5.797 
5.797 Update your lockfile using "pnpm install --no-frozen-lockfile"
```
 为顺利完成 Docker build在 dockerfile 中的 --frozen-lockfile 改为了   --no-frozen-lockfile。但是我查了资料还是有风险的。

在 Dockerfile 中使用 pnpm install 时，--frozen-lockfile 和 --no-frozen-lockfile 的主要区别：

--frozen-lockfile:
严格按照 pnpm-lock.yaml 文件安装依赖
如果 pnpm-lock.yaml 和 package.json 不匹配，会报错并终止安装
适用于生产环境构建，确保依赖版本完全一致
相当于 npm ci 命令

--no-frozen-lockfile:
允许在安装过程中更新 pnpm-lock.yaml
如果依赖版本有更新，会自动更新到符合 package.json 规范的最新版本
适用于开发环境
相当于普通的 npm install 命令
建议:

在生产环境构建使用 --frozen-lockfile，确保依赖版本的一致性和可重现性
在开发环境可以使用 --no-frozen-lockfile，方便获取依赖的更新


```bash
./node_modules/.pnpm/lock.yaml:4: autoInstallPeers: false
./pnpm-lock.yaml:4: autoInstallPeers: false
```
 pnpm 的相关配置
主要作用：
当设置为 false 时，不会自动安装 peer dependencies
只有在 package.json 中明确列出的 peer dependencies 才会被安装
如果缺少必要的 peer dependencies，会收到警告信息